### PR TITLE
Support of Historical dates (years only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test:verbose": "jest --verbose false --silent false",
     "test:profile": "node --inspect-brk ./node_modules/jest/bin/jest.js",
     "build": "tsc && vite build && echo '{\"type\": \"commonjs\"}' > cjs/package.json",
     "prepublish": "tsc && jest",

--- a/src/dateRange/getDateRangeFromBCEDateRegexMatch.ts
+++ b/src/dateRange/getDateRangeFromBCEDateRegexMatch.ts
@@ -1,0 +1,128 @@
+import {DateTime} from "luxon";
+import {ParsingContext} from "../ParsingContext.js";
+import {Caches} from "../Cache.js";
+import {
+    BCEDatePartMatchIndex,
+    fromYear_BCEDateIndex,
+    toYear_BCEDateIndex,
+    BCEEventTextMatchIndex,
+    BCE_START_REGEX, fromYearNotation_BCEDateIndex, toYearNotation_BCEDateIndex,
+} from "../regex.js";
+import {
+    DateRangePart,
+    DateTimeGranularity,
+    RangeType,
+    Range,
+} from "../Types.js";
+import {
+    roundDateUp,
+    getYearNotationToDatetime
+} from "./utils.js";
+
+export function getDateRangeFromBCEDateRegexMatch(
+    line: string,
+    i: number,
+    lengthAtIndex: number[],
+    context: ParsingContext,
+    cache?: Caches
+): DateRangePart | undefined {
+
+    // Check if its this type of event ---------------------------------------------------------------------------------
+    const eventStartLineRegexMatch = line.match(BCE_START_REGEX);
+    if (!eventStartLineRegexMatch) {
+        return;
+    }
+    // It's a match we want to proceed ---------------------------------------------------------------------------------
+    const datePart = eventStartLineRegexMatch[BCEDatePartMatchIndex];
+
+    // Extract date FROM parts -----------------------------------------------------------------------------------------
+    const BCEFromYear = eventStartLineRegexMatch[fromYear_BCEDateIndex];
+    const BCEFromYearNotation = eventStartLineRegexMatch[fromYearNotation_BCEDateIndex] || eventStartLineRegexMatch[toYearNotation_BCEDateIndex];
+    // TODO: implement support of month and day.
+
+    // Extract date TO parts -------------------------------------------------------------------------------------------
+    const BCEToYear = eventStartLineRegexMatch[toYear_BCEDateIndex];
+    const BCEToYearNotation = eventStartLineRegexMatch[toYearNotation_BCEDateIndex]
+    // TODO: implement support of month and day.
+
+    const indexOfDateRange = line.indexOf(datePart);
+    const dateRangeInText: Range = {
+        type: RangeType.DateRange,
+        from: lengthAtIndex[i] + indexOfDateRange,
+        to: lengthAtIndex[i] + indexOfDateRange + datePart.length,
+    };
+
+    context.ranges.push(dateRangeInText);
+
+    const colonIndex = line.indexOf(":", indexOfDateRange + datePart.length);
+    const colonRange = (rangeType: RangeType) => ({
+        type: rangeType,
+        from: lengthAtIndex[i] + colonIndex,
+        to: lengthAtIndex[i] + colonIndex + 1,
+    });
+    const cached = cache?.zone(context.timezone).ranges.get(datePart);
+    if (cached) {
+        context.ranges.push(colonRange(RangeType.DateRangeColon));
+        return new DateRangePart(
+            DateTime.fromISO(cached.fromDateTimeIso, {setZone: true}),
+            DateTime.fromISO(cached.toDateTimeIso, {setZone: true}),
+            datePart,
+            dateRangeInText,
+            eventStartLineRegexMatch[BCEEventTextMatchIndex]
+        );
+    }
+
+    let fromDateTime: DateTime | undefined;
+    let endDateTime: DateTime | undefined;
+    let granularity: DateTimeGranularity = "year";
+    let canCacheRange = true;
+
+    if (BCEFromYear) {
+        fromDateTime = getYearNotationToDatetime(BCEFromYear, BCEFromYearNotation, context);
+    } else {
+        // Not supported
+        return;
+    }
+
+    if (!fromDateTime || !fromDateTime?.isValid) {
+        fromDateTime = context.now.setZone(context.timezone);
+        granularity = "instant";
+    }
+
+    if (!endDateTime) {
+        if (BCEToYear) {
+            endDateTime = getYearNotationToDatetime(BCEToYear, BCEToYearNotation, context);
+        }
+    }
+
+    if (!endDateTime || !endDateTime.isValid) {
+        endDateTime = DateTime.fromISO(
+            roundDateUp(
+                {
+                    dateTimeIso: fromDateTime.toISO(),
+                    granularity,
+                },
+                context,
+                cache
+            ),
+            {setZone: true, zone: context.timezone}
+        );
+    }
+
+    context.ranges.push(colonRange(RangeType.DateRangeColon));
+    const dateRange = new DateRangePart(
+        fromDateTime,
+        endDateTime,
+        datePart,
+        dateRangeInText,
+        eventStartLineRegexMatch[BCEEventTextMatchIndex]
+    );
+
+    if (canCacheRange) {
+        cache?.zone(context.timezone).ranges.set(datePart, {
+            fromDateTimeIso: fromDateTime.toISO(),
+            toDateTimeIso: endDateTime.toISO(),
+        });
+    }
+    return dateRange;
+}

--- a/src/dateRange/utils.ts
+++ b/src/dateRange/utils.ts
@@ -495,3 +495,23 @@ export function roundDateUp(
       .toISO()
   );
 }
+
+export function getYearNotationToDatetime(
+  year: string|number,
+  yearNotation:string|undefined,
+  context: ParsingContext
+): DateTime | undefined {
+
+  if (typeof year === "string") {
+    year = parseInt(year);
+  }
+
+  if (yearNotation && (yearNotation === "BCE" || yearNotation === "BC")) {
+    /**
+     * It's a negative date and we need to remove 1 year to get the correct year
+     * The reason is that the year 0 does not exist in the Gregorian calendar
+     **/ 
+    year = -(year - 1);
+  }
+  return DateTime.fromObject({ year }, { zone: context.timezone });
+}

--- a/src/lineChecks/checkEvent.ts
+++ b/src/lineChecks/checkEvent.ts
@@ -1,8 +1,10 @@
 import { getDateRangeFromCasualRegexMatch } from "../dateRange/getDateRangeFromCasualRegexMatch.js";
 import { getDateRangeFromEDTFRegexMatch } from "../dateRange/getDateRangeFromEDTFRegexMatch.js";
+import { getDateRangeFromBCEDateRegexMatch } from "../dateRange/getDateRangeFromBCEDateRegexMatch";
 import {
   EDTF_START_REGEX,
   EVENT_START_REGEX,
+  BCE_START_REGEX,
   GROUP_START_REGEX,
   GROUP_END_REGEX,
   COMPLETION_REGEX,
@@ -21,6 +23,7 @@ import { ParsingContext } from "../ParsingContext.js";
 import { checkTags } from "./checkTags.js";
 import { parseZone } from "../zones/parseZone.js";
 import { parseProperties } from "../parseHeader.js";
+
 
 function updateParseMetadata(
   event: Event,
@@ -99,6 +102,15 @@ export function checkEvent(
     );
   }
   if (!dateRange) {
+    dateRange = getDateRangeFromBCEDateRegexMatch(
+        line,
+        i,
+        lengthAtIndex,
+        context,
+        cache
+    );
+  }
+  if (!dateRange) {
     return i;
   }
 
@@ -120,6 +132,7 @@ export function checkEvent(
       typeof nextLine !== "string" ||
       nextLine.match(EDTF_START_REGEX) ||
       nextLine.match(EVENT_START_REGEX) ||
+      nextLine.match(BCE_START_REGEX) ||
       nextLine.match(GROUP_START_REGEX) ||
       (context.currentPath.length > 1 && nextLine.match(GROUP_END_REGEX))
     ) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,6 +6,7 @@ import {
 } from "./Types.js";
 import { getDateRangeFromCasualRegexMatch } from "./dateRange/getDateRangeFromCasualRegexMatch.js";
 import { getDateRangeFromEDTFRegexMatch } from "./dateRange/getDateRangeFromEDTFRegexMatch.js";
+import { getDateRangeFromBCEDateRegexMatch } from "./dateRange/getDateRangeFromBCEDateRegexMatch.js";
 import { Caches } from "./Cache.js";
 import { checkEvent } from "./lineChecks/checkEvent.js";
 import { ParsingContext } from "./ParsingContext.js";
@@ -40,6 +41,14 @@ export function parseDateRange(
       0,
       [],
       parsingContext
+    );
+  }
+  if (!dateRange) {
+    dateRange = getDateRangeFromBCEDateRegexMatch(
+        dateRangeString,
+        0,
+        [],
+        parsingContext
     );
   }
   return dateRange;

--- a/src/parseHeader.ts
+++ b/src/parseHeader.ts
@@ -7,6 +7,7 @@ import {
 } from "./Types.js";
 import { checkComments } from "./lineChecks/checkComments.js";
 import {
+  BCE_START_REGEX,
   EDTF_START_REGEX,
   EVENT_START_REGEX,
   GROUP_START_REGEX,
@@ -30,6 +31,7 @@ const headerValueRegex = /(:)\s+(.+)$/;
 const eventsStarted = (line: string) =>
   !!line.match(EDTF_START_REGEX) ||
   !!line.match(EVENT_START_REGEX) ||
+  !!line.match(BCE_START_REGEX) ||
   !!line.match(GROUP_START_REGEX);
 
 const threeDashRegex = /^---/;

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -370,3 +370,38 @@ export const recurrence_edtfRecurrenceAmountXNotationAmountMatchIndex =
   ++edtfIndex;
 
 export const edtfEventTextMatchIndex = ++edtfIndex;
+
+
+/**
+ * BCE/CE System:
+ *
+ * Entirely BCE: 300–200 BCE
+ * Entirely CE: 100–200 CE (or simply 100–200 if context is clear)
+ * Crossing BCE to CE: 50 BCE–50 CE
+ *
+ * BC/AD System:
+ *  /!\ Although BC === BCE and AD === CE, official formating isn't the same for AD
+ *  which normally is positioned as prefix of the date: "AD 100", "100 BC-AD 70"
+ *
+ * BUT FOR easier implementation  only this format will be supported:
+ * Entirely BC: 300–200 BC
+ * Entirely AD: 100 AD–200 AD (or simply 100–200 if context is clear)
+ * Crossing BC to AD: 50 BC– 50 AD
+ *
+ * Number of digits: Arbitrary decision to stick to 4 digits
+ * - 4 cover most of the case which cover the Holocene period
+ * - 5,6 digits could be used for paleolithic but its overkill
+ * - we could also not limit... {1,}
+ *
+ */
+export const BCE_START_REGEX = new RegExp(
+    `^\\s*(\\d{1,5})\\s?(BCE|BC|AD|CE)?(?:\\s?[–-]\\s?(\\d{1,5})\\s?(BCE|BC|AD|CE)?)?(?=\\s*:?)(.*)`,
+    "i"
+);
+let BCEIndex = -1;
+export const BCEDatePartMatchIndex = ++BCEIndex;
+export const fromYear_BCEDateIndex = ++BCEIndex;
+export const fromYearNotation_BCEDateIndex = ++BCEIndex;
+export const toYear_BCEDateIndex = ++BCEIndex;
+export const toYearNotation_BCEDateIndex = ++BCEIndex;
+export const BCEEventTextMatchIndex = ++BCEIndex;

--- a/tests/dates.test.ts
+++ b/tests/dates.test.ts
@@ -1,0 +1,99 @@
+import { parse, parseDateRange } from "../src";
+import {
+  toDateRange,
+} from "../src";
+import { DateTime } from "luxon";
+import {
+  firstEvent,
+} from "./testUtilities";
+
+
+/**
+ * NOTE: I find it weird that the expectedTo date is always the next day at 00:00:00. Shouldn't it be the same day at 23:59:59?
+ */
+describe('Regular dates parsing', () => {
+    // List the case
+    const testCases = [
+        // The Common usage case (relatively recent/present dates)
+        {
+            mwInput: '2025-05-11: The day the music died',
+            expectedFrom: DateTime.fromObject({ year: 2025, month: 5, day: 11 }),
+            //expectedTo: DateTime.fromObject({ year: 2025, month: 5, day: 11 })
+            expectedTo: DateTime.fromObject({ year: 2025, month: 5, day: 12 })
+        },
+        {
+            mwInput: '1999 - 2099: a century of events',
+            expectedFrom: DateTime.fromObject({ year: 1999, month: 1, day: 1 }),
+            expectedTo: DateTime.fromObject({ year: 2100, month: 1, day: 1 })
+        },
+        {
+            mwInput: '2026 - 2029: so many events',
+            expectedFrom: DateTime.fromObject({ year: 2026, month: 1, day: 1 }),
+            expectedTo: DateTime.fromObject({ year: 2030, month: 1, day: 1 })
+        },
+        // TODO: Import case from main.test.ts
+    
+        // Dwell into the past with BCE dates (relatively ancient dates)
+        // note: BCE (Before the Common Era) === BC (Before Christ)
+        // note: CE (Common Era) === AD (Anno Domini)
+        //
+        // IMPORTANT: expected date are 1 year less than input. its because there's no year 0.
+        // From 1 BCE we go to 1 CE (no 0 while in javascript we do have year 0)
+        {
+            mwInput: '1000 BCE: The Iron Age',
+            expectedFrom: DateTime.fromObject({ year: -999, month: 1, day: 1 }),
+            expectedTo: DateTime.fromObject({ year: -998, month: 1, day: 1 })
+        },
+        {
+            mwInput: "586 BCE: The Siege of Jerusalem",
+            expectedFrom: DateTime.fromObject({ year: -585, month: 1, day: 1 }),
+            expectedTo: DateTime.fromObject({ year: -584, month: 1, day: 1 })
+        },
+        {
+            mwInput: '285–247 BCE: Ptolemy II Philadelphus',
+            expectedFrom: DateTime.fromObject({ year: -284, month: 1, day: 1 }),
+            expectedTo: DateTime.fromObject({ year: -246, month: 1, day: 1 })
+        },
+        {
+            mwInput: "586 BC- 70 AD: Second Temple period which end by the Siege of Jerusalem by the Romans",
+            expectedFrom: DateTime.fromObject({ year: -585, month: 1, day: 1 }),
+            expectedTo: DateTime.fromObject({ year: 70, month: 1, day: 1 })
+        }
+    ];
+
+    // Test Each case against parseDateRange
+    testCases.forEach(({ mwInput, expectedFrom, expectedTo }) => {
+        test(`Should correctly parseDateRange: "${mwInput}"`, () => {
+            // Process ----
+            const dateRange = parseDateRange(mwInput);
+            expect(dateRange).toBeTruthy();
+            const from = dateRange?.fromDateTime;
+            const to = dateRange?.toDateTime;
+            // Test result ----
+            expect(from?.year).toEqual(expectedFrom.year);
+            expect(from?.month).toEqual(expectedFrom.month);
+            expect(from?.day).toEqual(expectedFrom.day);
+            expect(to?.year).toEqual(expectedTo.year);
+            expect(to?.month).toEqual(expectedTo.month);
+            expect(to?.day).toEqual(expectedTo.day);
+        });
+    });
+
+    // Test Each case against parse
+    testCases.forEach(({ mwInput, expectedFrom, expectedTo }) => {
+        test(`Should correctly parse "${mwInput}"`, () => {
+            // Process ----
+            const markwhen = parse(mwInput);
+            const dateRange = toDateRange(firstEvent(markwhen).dateRangeIso);
+            const from = dateRange.fromDateTime;
+            const to = dateRange.toDateTime;
+            // Test result ----
+            expect(from?.year).toEqual(expectedFrom.year);
+            expect(from?.month).toEqual(expectedFrom.month);
+            expect(from?.day).toEqual(expectedFrom.day);
+            expect(to?.year).toEqual(expectedTo.year);
+            expect(to?.month).toEqual(expectedTo.month);
+            expect(to?.day).toEqual(expectedTo.day);
+        });
+    });
+});


### PR DESCRIPTION
# Implement support for historical date
This branch is to implement support for BCE/BC and CE/AD dates.
This implementation cover only the Year and will not works with month, day etc.

## Note:
Implementation was done only with the added test to verify it's working. Maybe some additional testing would be needed

## Changes
- Add regex for the BCE dates
- Add case where needed to parse BCE dates
- Add Method to get Datetime from a year and its notation to cover that year 0 doesn't exist (we go from 1BCE to 1AD) but in javascript year 0 exist
- Add Tests

## Known issues:
- AD dates are supposed to be formatted with AD then Year (`AD 70`). For simplicity and to align with other notation AD should be after the year: "5 AD: Some event"
- Currently you cannot mix and match EDF/Event dates and BCE dates. It means you cannot have something like: "250BC - 01/01/70". You need to set "70 AD" or "70 CE"

## Example:
Refer to `tests/dates.test.ts` to see some examples


## Tests result:
Failing test are already failing on main branch:
```
# main branch
Test Suites: 2 failed, 5 passed, 7 total
Tests:       4 failed, 12 skipped, 476 passed, 492 total
Snapshots:   0 total
Time:        9.793 s
```
This branch
```
 PASS  tests/regex.test.ts (5.256 s)
 FAIL  tests/ical.test.ts (5.45 s)
 PASS  tests/recurrence.test.ts (5.455 s)
 PASS  tests/dates.test.ts (5.605 s)
 PASS  tests/entryProperties.test.ts (5.509 s)
 PASS  tests/zones.test.ts (5.568 s)
 FAIL  tests/header.test.ts (5.641 s)
 PASS  tests/main.test.ts (6.067 s)
 
Test Suites: 2 failed, 6 passed, 8 total
Tests:       4 failed, 12 skipped, 489 passed, 505 total
Snapshots:   0 total
Time:        6.788 s, estimated 7 s
```

