### PR TITLE
fix: extend BCE regex from 5 to 7 digits for paleolithic dates

### DIFF
--- a/src/regex.ts
+++ b/src/regex.ts
@@ -359,7 +359,7 @@ export const edtfEventTextMatchIndex = ++edtfIndex;
  *
  */
 export const BCE_START_REGEX = new RegExp(
-  `^\\s*(\\d{1,5})\\s?(BCE|BC|AD|CE)?(?:\\s?[–-]\\s?(\\d{1,5})\\s?(BCE|BC|AD|CE)?)?(?=\\s*:)(.*)`,
+  `^\\s*(\\d{1,7})\\s?(BCE|BC|AD|CE)?(?:\\s?[–-]\\s?(\\d{1,7})\\s?(BCE|BC|AD|CE)?)?(?=\\s*:)(.*)`,
   "i"
 );
 let BCEIndex = -1;


### PR DESCRIPTION
The BCE_START_REGEX was limited to 5 digits (max 99,999 BCE), which prevented parsing dates commonly used in archaeology, such as `800000 BCE - 300000 BCE` (Lower Paleolithic).  

The existing comment even noted this possibility: > "5,6 digits could be used for paleolithic but its overkill"  

As an archaeologist building a timeline of prehistoric periods in, I hit this limit directly. Changing `{1,5}` to `{1,7}` supports dates up to 9,999,999 BCE — covering all of human prehistory — with no performance impact. 